### PR TITLE
Use project_slug in place of long formatting string everywhere

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ pytest
 Code coverage of Python scripts is measured using the [`coverage` Python
 package][coverage]; its configuration can be found in `pyproject.toml`. Note coverage
 only extends to Python scripts in the `hooks`, and
-`{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}/{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}` folders.
+`{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}` folders.
 
 To run code coverage, and view it as an HTML report, enter the following command in
 your terminal:

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ The cookiecutter template generated for each project will follow this folder str
 ```shell
 .
 └── govcookiecutter/
-    ├── {{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}/
-    │   └── {{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}/
+    ├── {{ cookiecutter.project_slug }}/
+    │   └── {{ cookiecutter.project_slug }}/
     │       ├── example_modules/
     │       │   ├── __init__.py
     │       │   └── example_module.py

--- a/docs/contributing_guide/docs_contributor_README.md
+++ b/docs/contributing_guide/docs_contributor_README.md
@@ -7,6 +7,6 @@ This is the contributor guide for the `govcookiecutter` project.
 ../CODE_OF_CONDUCT.md
 ../CONTRIBUTING.md
 ./modify_govcookiecutter.md
-../{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}/.govcookiecutter/organisational_frameworks/docs_repo_frameworks_README.md
+../{{ cookiecutter.project_slug }}/.govcookiecutter/organisational_frameworks/docs_repo_frameworks_README.md
 
 ```

--- a/docs/contributing_guide/modify_govcookiecutter.md
+++ b/docs/contributing_guide/modify_govcookiecutter.md
@@ -20,10 +20,10 @@ cookiecutter https://github.com/best-practice-and-impact/govcookiecutter.git
 you'll see a list of prompts to answer; one of them is `project_name`.
 
 Your answer for `project_name` is used to overwrite every instance of
-`{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}`. The first instance is the `govcookiecutter` folder
-`{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}`, which becomes your outputted project!
+`{{ cookiecutter.project_slug }}`. The first instance is the `govcookiecutter` folder
+`{{ cookiecutter.project_slug }}`, which becomes your outputted project!
 
-This means every folder and file contained within the `{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}`
+This means every folder and file contained within the `{{ cookiecutter.project_slug }}`
 folder becomes part of your output project, including their content. Anything else
 outside of this folder in `govcookiecutter` will not exist in the outputted project.
 
@@ -33,7 +33,7 @@ The prompts, and their default responses are defined in `cookiecutter.json`. Her
 keys starting with `_` are not shown to the user, but provide template extensions.
 
 One such extension is `jinja2_time.TimeExtension`, which is used to add the correct
-year in the `{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}/LICENSE` file.
+year in the `{{ cookiecutter.project_slug }}/LICENSE` file.
 
 All other keys are used to inject the user responses throughout the template. This
 happens wherever you see `{{ cookiecutter.{KEY} }}`, where `{KEY}` is the key in
@@ -73,7 +73,7 @@ defined in `hooks/post_gen_project.py`. These hooks only run after a project has
 generated and, if they fail, will rollback the entire project.
 
 Conditional files and folders are defined as `features` in the
-`{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}/manifest.json` file, which looks like:
+`{{ cookiecutter.project_slug }}/manifest.json` file, which looks like:
 
 ```
 {
@@ -136,11 +136,11 @@ These are performed in the `hooks/post_gen_project.py`file.
 ## Tests, coverage, and continuous integration
 
 All pre- and post-generation hooks should be fully tested, alongside any generic
-functions that we want to supply to users within the `{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}`
+functions that we want to supply to users within the `{{ cookiecutter.project_slug }}`
 package. These tests should be written in `tests` or
-`{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}/tests` as appropriate.
+`{{ cookiecutter.project_slug }}/tests` as appropriate.
 
-Coverage also only covers the `hooks` and `{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}/{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}` folders.
+Coverage also only covers the `hooks` and `{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}` folders.
 
 ### Testing Jinja templating
 
@@ -148,7 +148,7 @@ Most of the tests are straightforward, and comprehensive. However, to test the J
 injection of user responses, the `test_govcookiecutter_injected_variables.py` script
 adopts a test-driven development approach to completeness.
 
-This test parses all the content of the `{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}` folder, and
+This test parses all the content of the `{{ cookiecutter.project_slug }}` folder, and
 counts the number of times the replacement variable and its variations appear.
 
 The constant dictionary variables at the top of the test script define the different

--- a/docs/docs_README.md
+++ b/docs/docs_README.md
@@ -6,8 +6,8 @@ This folder contains documentation for `govcookiecutter`. These are written in M
 Further details to consider when modifying these files are supplied in the [contributing guidance][contributing-guidance].
 ```
 
-To include documentation from the `{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}`
-folder without duplicating it, refer to it in a file within the `docs/{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}` folder.
+To include documentation from the `{{ cookiecutter.project_slug }}`
+folder without duplicating it, refer to it in a file within the `docs/{{ cookiecutter.project_slug }}` folder.
 
 To build the documentation, run:
 

--- a/docs/govcookiecutter_structure/docs_structure_README.md
+++ b/docs/govcookiecutter_structure/docs_structure_README.md
@@ -9,7 +9,7 @@ Further detail on folder contents is available:
 ./example.md
 ./hooks.md
 ./tests.md
-../{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}/docs_repo_README.md
+../{{ cookiecutter.project_slug }}/docs_repo_README.md
 ```
 
 ## Top-level files
@@ -101,7 +101,7 @@ Python imports are arranged according to the [specification defined by `black`][
 
 #### `pytest`
 
-To run the tests within the `tests`, and `{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}/tests` folders
+To run the tests within the `tests`, and `{{ cookiecutter.project_slug }}/tests` folders
 using the `pytest` Python package, enter the following command:
 
 ```shell
@@ -125,7 +125,7 @@ make coverage_html
 ```
 
 A code coverage report in HTML will be produced on the code in the `hooks` and
-`{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}/{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}` folders.
+`{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}` folders.
 This HTML report can be accessed at `htmlcov/index.html`.
 
 ### `README.md`

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,6 @@
 self
 ./contributing_guide/docs_contributor_README.md
 ./govcookiecutter_structure/docs_structure_README.md
-./{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}/docs_repo_README.md
+./{{ cookiecutter.project_slug }}/docs_repo_README.md
 ./reference/docs_ref_README.md
 ```

--- a/docs/{{ cookiecutter.repo_name }}/.govcookiecutter/organisational_frameworks/docs_repo_frameworks_README.md
+++ b/docs/{{ cookiecutter.repo_name }}/.govcookiecutter/organisational_frameworks/docs_repo_frameworks_README.md
@@ -1,2 +1,2 @@
-```{include} ../../../../{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}/.govcookiecutter/organisational_frameworks/framework_README.md
+```{include} ../../../../{{ cookiecutter.project_slug }}/.govcookiecutter/organisational_frameworks/framework_README.md
 ```

--- a/docs/{{ cookiecutter.repo_name }}/docs.md
+++ b/docs/{{ cookiecutter.repo_name }}/docs.md
@@ -1,2 +1,2 @@
-```{include} ../../{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}/docs/repo_docs_README.md
+```{include} ../../{{ cookiecutter.project_slug }}/docs/repo_docs_README.md
 ```

--- a/docs/{{ cookiecutter.repo_name }}/docs_repo_README.md
+++ b/docs/{{ cookiecutter.repo_name }}/docs_repo_README.md
@@ -1,7 +1,7 @@
-# `{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}` folder structure
+# `{{ cookiecutter.project_slug }}` folder structure
 
 This is information about the structure of the created repository contained
-in the `{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}` folder within the `govcookiecutter` repository.
+in the `{{ cookiecutter.project_slug }}` folder within the `govcookiecutter` repository.
 Some of these files may not be present in the actual created repository, as this is
 customised based on the user's answers to the prompts on set-ups.
 

--- a/docs/{{ cookiecutter.repo_name }}/source_code.md
+++ b/docs/{{ cookiecutter.repo_name }}/source_code.md
@@ -1,4 +1,4 @@
-# `{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}` folder overview
+# `{{ cookiecutter.project_slug }}` folder overview
 
 This is where source code for the created project is stored. We recommend following a standard Python project structure,
 with functions grouped into modules inside a descriptively named folder. The created repository contains an `example_module.py`

--- a/docs/{{ cookiecutter.repo_name }}/tests.md
+++ b/docs/{{ cookiecutter.repo_name }}/tests.md
@@ -1,2 +1,2 @@
-```{include} ../../{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}/tests/repo_tests_README.md
+```{include} ../../{{ cookiecutter.project_slug }}/tests/repo_tests_README.md
 ```

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -16,5 +16,7 @@ def check_repo_name_structure(repo_name: str) -> None:
 
 if __name__ == "__main__":
 
+    {{ cookiecutter.update({"project_slug": cookiecutter.project_name.lower()|replace(' ', '_')|replace('-', '_')|replace('.', '_')|trim() }) }}
+
     # Check the format of the contact email address supplied is a valid one
-    check_repo_name_structure("{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}")
+    check_repo_name_structure("{{ cookiecutter.project_slug }}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,10 +2,10 @@
 [tool.coverage.run]
 source = [
     "./hooks",
-    "./{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}/{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}"
+    "./{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}"
 ]
 omit = [
-    "./{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}/{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}/run_pipeline.py"
+    "./{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/run_pipeline.py"
 ]
 
 [tool.coverage.omit]
@@ -26,7 +26,7 @@ addopts = [
     "--doctest-modules",
     "--ignore='./docs/'",
     "--ignore='./example/'",
-    "--ignore='./{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}/docs/'"
+    "--ignore='./{{ cookiecutter.project_slug }}/docs/'"
 ]
 doctest_optionflags = "NORMALIZE_WHITESPACE"
 testpaths = [

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -4,7 +4,7 @@ from typing import Dict, List
 from dotenv import dotenv_values
 
 # Define a path to the `govcookiecutter` template directory, and its `.env` file
-DIR_TEMPLATE = Path("{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}")
+DIR_TEMPLATE = Path("{{ cookiecutter.project_slug }}")
 PATH_TEMPLATE_ENV = DIR_TEMPLATE.joinpath(".env")
 
 # Define a list of directory names to recursively ignore, as well as a list of
@@ -119,7 +119,7 @@ def define_expected_env_variables(
         ):
             if (
                 d.name.upper()
-                == "{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}".upper()  # noqa: E501
+                == "{{ cookiecutter.project_slug }}".upper()  # noqa: E501
             ):
                 env_expected_dir_variable = loop_directories_children(
                     d, env_expected_dir_variable

--- a/{{ cookiecutter.project_name }}/CODE_OF_CONDUCT.md
+++ b/{{ cookiecutter.project_name }}/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
-# Code of conduct for `{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}`
+# Code of conduct for `{{ cookiecutter.project_slug }}`
 
 [Our code of conduct can be found at
 `docs/contributor_guide/CODE_OF_CONDUCT.md`][code-of-conduct].

--- a/{{ cookiecutter.project_name }}/README.md
+++ b/{{ cookiecutter.project_name }}/README.md
@@ -1,4 +1,4 @@
-# `{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}`
+# `{{ cookiecutter.project_slug }}`
 
 A placeholder description for your python project
 
@@ -6,7 +6,7 @@ A placeholder description for your python project
 Where this documentation refers to the root folder we mean where this README.md is
 located.
 ```
-## What is `{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}`?
+## What is `{{ cookiecutter.project_slug }}`?
 
 Add a summary of your project here.
 
@@ -59,7 +59,7 @@ To run the pipeline, run the following code in the terminal (either in the root 
 project, or by specifying the path to `run_pipeline.py` from elsewhere).
 
 ```shell
-python src/{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}/run_pipeline.py
+python src/{{ cookiecutter.project_slug }}/run_pipeline.py
 ```
 
 Alternatively, most Python IDEs allow you to run the code directly using a `run` button.
@@ -84,8 +84,8 @@ The cookiecutter template generated for each project will follow this folder str
 
 ```shell
 .
-├── {{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}/
-│   └── {{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}/
+├── {{ cookiecutter.project_slug }}/
+│   └── {{ cookiecutter.project_slug }}/
 │       ├── example_modules/
 │       │   ├── __init__.py
 │       │   └── example_module.py
@@ -103,7 +103,7 @@ Crown copyright and available under the terms of the Open Government 3.0 licence
 
 ## Contributing
 
-If you want to help us build and improve `{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}`, please take a look at our
+If you want to help us build and improve `{{ cookiecutter.project_slug }}`, please take a look at our
 [contributing guidelines][contributing].
 
 ## Acknowledgements

--- a/{{ cookiecutter.project_name }}/docs/conf.py
+++ b/{{ cookiecutter.project_name }}/docs/conf.py
@@ -165,7 +165,7 @@ html_static_path = ["_static"]
 # html_search_scorer = "scorer.js"
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = "{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}doc"
+htmlhelp_basename = "{{ cookiecutter.project_slug }}doc"
 
 # -- Options for autosection output ----------------
 

--- a/{{ cookiecutter.project_name }}/docs/contributor_guide/CODE_OF_CONDUCT.md
+++ b/{{ cookiecutter.project_name }}/docs/contributor_guide/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
-# Code of conduct for `{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}`
+# Code of conduct for `{{ cookiecutter.project_slug }}`
 
 All contributors to this repository hosted by `{{ cookiecutter.organisation_handle }}` are expected to follow the
 Contributor Covenant Code of Conduct. Those working within HM Government are also expected to follow the [Civil Service
@@ -10,7 +10,7 @@ Code][civil-service-code].
 
 Where this Code of Conduct says:
 
-- "Project", we mean this repository `{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}` ;
+- "Project", we mean this repository `{{ cookiecutter.project_slug }}` ;
 - "Maintainer", we mean active developers of the primary project team(s) behind `{{ cookiecutter.organisation_handle }}`; and
 - "Leadership", we mean `{{ cookiecutter.organisation_handle }}` organisation owners, line managers, and other
   leadership within the {{ cookiecutter.organisation_name }}.

--- a/{{ cookiecutter.project_name }}/docs/contributor_guide/CONTRIBUTING.md
+++ b/{{ cookiecutter.project_name }}/docs/contributor_guide/CONTRIBUTING.md
@@ -69,7 +69,7 @@ pytest
 
 Code coverage of Python scripts is measured using the [`coverage` Python
 package][coverage]; its configuration can be found in `pyproject.toml`. Note coverage
-only extends to Python scripts in the `{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}` folder.
+only extends to Python scripts in the `{{ cookiecutter.project_slug }}` folder.
 
 To run code coverage, and view it as an HTML report, enter the following command in
 your terminal:

--- a/{{ cookiecutter.project_name }}/docs/contributor_guide/contributor_README.md
+++ b/{{ cookiecutter.project_name }}/docs/contributor_guide/contributor_README.md
@@ -1,6 +1,6 @@
 # Contributing guide
 
-This is the contributor guide for the `{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}` project.
+This is the contributor guide for the `{{ cookiecutter.project_slug }}` project.
 
 ```{toctree}
 :maxdepth: 2

--- a/{{ cookiecutter.project_name }}/docs/user_guide/user_guide_README.md
+++ b/{{ cookiecutter.project_name }}/docs/user_guide/user_guide_README.md
@@ -1,6 +1,6 @@
 # User guide
 
-This is the user guide for the `{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}` project.
+This is the user guide for the `{{ cookiecutter.project_slug }}` project.
 
 ```{toctree}
 :maxdepth: 2

--- a/{{ cookiecutter.project_name }}/tests/repo_tests_README.md
+++ b/{{ cookiecutter.project_name }}/tests/repo_tests_README.md
@@ -1,3 +1,3 @@
 # `tests` folder overview
 
-All tests for the functions defined in the `{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}` folder should be stored here.
+All tests for the functions defined in the `{{ cookiecutter.project_slug }}` folder should be stored here.


### PR DESCRIPTION
# Summary

Added code to pre_gen_project.py to add cookiecutter.project_slug without the user getting prompted to give an input for it.

# Checklists

<!--
These are DO-CONFIRM checklists; it CONFIRMs that you have DOne each item.

Outstanding actions should be completed before reviewers are assigned; if actions are
irrelevant, please try and add a comment stating why.

Incomplete pull/merge requests MAY be blocked until actions are resolved, or closed at
the reviewers' discretion.
-->

This pull/merge request meets the following requirements:

- [ ] code runs
- [ ] [developments are ethical][data-ethics-framework] and secure
- [ ] you have made proportionate checks that the code works correctly
- [ ] you have tested the build of the template
- [ ] test suite passes
- [ ] [minimum usable documentation][agilemodeling] written in the `docs` folder
- [ ] changelog has been updated

Comments have been added below around the incomplete checks.

[agilemodeling]: http://agilemodeling.com/essays/documentLate.htm
[data-ethics-framework]: https://www.gov.uk/government/publications/data-ethics-framework
